### PR TITLE
fix: Cannot read `flickrImages` of `undefined`

### DIFF
--- a/app/components/LaunchDetails/index.tsx
+++ b/app/components/LaunchDetails/index.tsx
@@ -105,7 +105,7 @@ function LaunchDetails({ missionName, links, details, rocket, ships, loading }: 
           condition={!isEmpty(links?.flickrImages)}
           otherwise={<CustomImage preview={false} src={placeholderImage} />}
         >
-          <CustomImage preview={false} src={links.flickrImages![0]} />
+          <CustomImage preview={false} src={links?.flickrImages![0]} />
         </If>
       </Skeleton>
       <Skeleton loading={loading} active>


### PR DESCRIPTION
### Ticket Link

---

### Related Links

---

### Description

---
- Fix bug "Cannot read `flickrImages` of `undefined`" error

### Steps to Reproduce / Test

---

---

### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

### GIF's

---
![Screenshot 2022-04-06 at 14 12 30](https://user-images.githubusercontent.com/98734275/161934403-f4db5357-a67f-4a9a-83ca-ea928ef818b4.png)
