### PR TITLE
fix: optipng module issue on armx64. Also added webp compressor

### DIFF
--- a/internals/webpack/webpack.config.base.js
+++ b/internals/webpack/webpack.config.base.js
@@ -123,11 +123,18 @@ module.exports = (options) => ({
                 interlaced: false
               },
               optipng: {
-                optimizationLevel: 7
+                enabled: false
+                // NOTE: optipng is disabled as it causes errors in some Mac M1 & M2 environments
+                // Try enabling it in your environment by switching the config to:
+                // enabled: true,
+                // optimizationLevel: 7
               },
               pngquant: {
                 quality: [0.65, 0.9],
                 speed: 4
+              },
+              webp: {
+                quality: 75
               }
             }
           }


### PR DESCRIPTION
### Ticket Link

---

### Related Links

---

### Description
optipng-bin module not found error on M1 & M2 armx64. Also added webp compressor
---

### Steps to Reproduce / Test
this is the same fix done in react-template, [refer](https://github.com/wednesday-solutions/react-template/pull/198).
---

---

### Checklist

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

### GIF's

---
